### PR TITLE
Simplify production yaml.

### DIFF
--- a/appveyor/prod/law-xml/appveyor.yml
+++ b/appveyor/prod/law-xml/appveyor.yml
@@ -46,16 +46,14 @@ before_build:
   - ps: $CONTENT_ARRAY = $REQUIREMENTS_CONTENT -split "# ";
   - ps: $env:PARTNER_NAMESPACE = $CONTENT_ARRAY[1];
 
-  - ps: $env:TAF_WHEEL = "taf"
         
   - "%PYTHON%\\python.exe -m pip -q install wheel"
-  - "%PYTHON%\\python.exe -m pip -q install %TAF_WHEEL%"
   - "%PYTHON%\\python.exe -m pip list"
 
   - "%PYTHON%\\python.exe  -m oll.tools.cli ci clone-repos --library-root .. --xml ../%APPVEYOR_PROJECT_SLUG% "
 
   # install versioned resources (if and only if the build is a tag or cron build)
-  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt --pre"
+  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
   - "%PYTHON%\\python.exe -m pip -q install pytest"
   # print out the git commits for xml repo
   - git -C ..\%UPSTREAM% rev-parse HEAD

--- a/appveyor/prod/law-xml/appveyor.yml
+++ b/appveyor/prod/law-xml/appveyor.yml
@@ -47,14 +47,12 @@ before_build:
   - ps: $env:PARTNER_NAMESPACE = $CONTENT_ARRAY[1];
 
         
-  - "%PYTHON%\\python.exe -m pip -q install wheel"
+  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip -q install pytest"
   - "%PYTHON%\\python.exe -m pip list"
 
   - "%PYTHON%\\python.exe  -m oll.tools.cli ci clone-repos --library-root .. --xml ../%APPVEYOR_PROJECT_SLUG% "
 
-  # install versioned resources (if and only if the build is a tag or cron build)
-  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
-  - "%PYTHON%\\python.exe -m pip -q install pytest"
   # print out the git commits for xml repo
   - git -C ..\%UPSTREAM% rev-parse HEAD
 

--- a/appveyor/prod/law-xml/appveyor.yml
+++ b/appveyor/prod/law-xml/appveyor.yml
@@ -40,31 +40,22 @@ install:
 
 before_build:
   # read requirements.txt and split it by # to get partners namespace.
-  # this is necessary because pytest expects an argument containing specific partner
+  # this is necessary because of roundtripping tests
   # example result:  oll.partners.us.ca.cities.san_mateo
   - ps: $REQUIREMENTS_CONTENT = Get-Content .\requirements.txt -Raw;
   - ps: $CONTENT_ARRAY = $REQUIREMENTS_CONTENT -split "# ";
   - ps: $env:PARTNER_NAMESPACE = $CONTENT_ARRAY[1];
 
   - ps: $env:TAF_WHEEL = "taf"
-  - ps: $env:CORE_WHEEL = "--pre oll-core"
-  - ps: >-
-        If($env:PARTNER_NAMESPACE -eq 'oll.partners.us.dc') {
-          $env:PARTNERS_WHEEL = "--pre oll-partners-us-dc"
-        } else {  
-          $env:PARTNERS_WHEEL = "--pre oll-partners"
-        };
         
   - "%PYTHON%\\python.exe -m pip -q install wheel"
   - "%PYTHON%\\python.exe -m pip -q install %TAF_WHEEL%"
-  - "%PYTHON%\\python.exe -m pip -q install %CORE_WHEEL%"
-  - "%PYTHON%\\python.exe -m pip -q install %PARTNERS_WHEEL%"
   - "%PYTHON%\\python.exe -m pip list"
 
   - "%PYTHON%\\python.exe  -m oll.tools.cli ci clone-repos --library-root .. --xml ../%APPVEYOR_PROJECT_SLUG% "
 
   # install versioned resources (if and only if the build is a tag or cron build)
-  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt --pre"
   - "%PYTHON%\\python.exe -m pip -q install pytest"
   # print out the git commits for xml repo
   - git -C ..\%UPSTREAM% rev-parse HEAD

--- a/appveyor/prod/law/appveyor.yml
+++ b/appveyor/prod/law/appveyor.yml
@@ -37,15 +37,14 @@ install:
 
 before_build:
 
-  - "%PYTHON%\\python.exe -m pip -q install wheel"
+  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip -q install pytest"
   - "%PYTHON%\\python.exe -m pip list"
 
   - "%PYTHON%\\python.exe  -m oll.tools.cli ci clone-repos --library-root .. --auth ../%APPVEYOR_PROJECT_SLUG% "
 
   - git -C ..\%APPVEYOR_PROJECT_SLUG% remote set-url origin git@github.com:%APPVEYOR_REPO_NAME%.git
 
-  - "%PYTHON%\\python.exe -m pip -q install wheel"
-  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
 
 
 build_script:

--- a/appveyor/prod/law/appveyor.yml
+++ b/appveyor/prod/law/appveyor.yml
@@ -37,18 +37,9 @@ install:
 
 before_build:
   - ps: $env:TAF_WHEEL = "taf"
-  - ps: $env:CORE_WHEEL = "--pre oll-core"
-  - ps: >-
-        If($env:PARTNER -eq 'OLL_PARTNERS_US_DC') {
-          $env:PARTNERS_WHEEL = "--pre oll-partners-us-dc"
-        } else {  
-          $env:PARTNERS_WHEEL = "--pre oll-partners"
-        };
         
   - "%PYTHON%\\python.exe -m pip -q install wheel"
   - "%PYTHON%\\python.exe -m pip -q install %TAF_WHEEL%"
-  - "%PYTHON%\\python.exe -m pip -q install %CORE_WHEEL%"
-  - "%PYTHON%\\python.exe -m pip -q install %PARTNERS_WHEEL%"
   - "%PYTHON%\\python.exe -m pip list"
 
   - "%PYTHON%\\python.exe  -m oll.tools.cli ci clone-repos --library-root .. --auth ../%APPVEYOR_PROJECT_SLUG% "
@@ -56,7 +47,7 @@ before_build:
   - git -C ..\%APPVEYOR_PROJECT_SLUG% remote set-url origin git@github.com:%APPVEYOR_REPO_NAME%.git
 
   - "%PYTHON%\\python.exe -m pip -q install wheel"
-  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt --pre"
 
 
 build_script:

--- a/appveyor/prod/law/appveyor.yml
+++ b/appveyor/prod/law/appveyor.yml
@@ -36,10 +36,8 @@ install:
 
 
 before_build:
-  - ps: $env:TAF_WHEEL = "taf"
-        
+
   - "%PYTHON%\\python.exe -m pip -q install wheel"
-  - "%PYTHON%\\python.exe -m pip -q install %TAF_WHEEL%"
   - "%PYTHON%\\python.exe -m pip list"
 
   - "%PYTHON%\\python.exe  -m oll.tools.cli ci clone-repos --library-root .. --auth ../%APPVEYOR_PROJECT_SLUG% "
@@ -47,7 +45,7 @@ before_build:
   - git -C ..\%APPVEYOR_PROJECT_SLUG% remote set-url origin git@github.com:%APPVEYOR_REPO_NAME%.git
 
   - "%PYTHON%\\python.exe -m pip -q install wheel"
-  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt --pre"
+  - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
 
 
 build_script:


### PR DESCRIPTION
* Since installing from `requiremens.txt` does exactly what the removed
  code does, simplify prod yml. Add `--pre` to `-r requirements.txt`.
* Still need to install taf, since `oll ci clone-repos` relies on having
  TAF installed.