### PR TITLE
feat: skip building already merged update branches

### DIFF
--- a/appveyor/dev/law/appveyor.yml
+++ b/appveyor/dev/law/appveyor.yml
@@ -1,6 +1,10 @@
 image:
   - Visual Studio 2019
 
+branches:
+  except:
+    - merged/update/*
+
 environment:
   matrix:
     # For Python versions available on Appveyor, see


### PR DESCRIPTION
The issue is that once update branch is merged, then renamed, AppVeyor triggers another build on the deleted branch. This is a bug related to Appveyor that is not fully resolved. To prevent notifications on our end, skip merged update branches