### PR TITLE
fix: add pip check to fail build on incomplete package installation

### DIFF
--- a/appveyor/dev/law-xml/appveyor.yml
+++ b/appveyor/dev/law-xml/appveyor.yml
@@ -107,12 +107,16 @@ test_script:
   - ps: >-
       if ($env:APPVEYOR_REPO_BRANCH -in @('master', 'main') -Or $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH -in @('master', 'main')){
         cd $env:APPVEYOR_BUILD_FOLDER;
-        $run_roundtrip = $env:PYTHON + '\python.exe -m pytest --pyargs ' + $env:PARTNER_NAMESPACE + '.tests.docs.code.roundtrip -m "full_roundtrip"';
-        iex $run_roundtrip;
-        if ($LastExitCode -eq 4 -or $LastExitCode -eq 5) {
-            Write-Warning "Skipping roundtrip tests - roundtrip tests not found";
-        } elseif ($LastExitCode -ne 0) {
-          $host.SetShouldExit($LastExitCode)
+        if ($env:PARTNER_NAMESPACE -eq 'oll.partners.us.dc') {
+          Write-Warning "Skipping roundtrip tests - not implemented for DC";
+        } else {
+          $run_roundtrip = $env:PYTHON + '\python.exe -m pytest --pyargs ' + $env:PARTNER_NAMESPACE + '.tests.docs.code.roundtrip -m "full_roundtrip"';
+          iex $run_roundtrip;
+          if ($LastExitCode -eq 4 -or $LastExitCode -eq 5) {
+              Write-Warning "Skipping roundtrip tests - roundtrip tests not found";
+          } elseif ($LastExitCode -ne 0) {
+            $host.SetShouldExit($LastExitCode)
+          }
         }
       } else {
         echo "Skipping rountrip tests - not master or main branch build";

--- a/appveyor/dev/law-xml/appveyor.yml
+++ b/appveyor/dev/law-xml/appveyor.yml
@@ -107,7 +107,7 @@ test_script:
   - ps: >-
       if ($env:APPVEYOR_REPO_BRANCH -in @('master', 'main') -Or $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH -in @('master', 'main')){
         cd $env:APPVEYOR_BUILD_FOLDER;
-        if ($env:PARTNER_NAMESPACE -eq 'oll.partners.us.dc') {
+        if ($env:PARTNER_NAMESPACE.Trim() -eq 'oll.partners.us.dc') {
           Write-Warning "Skipping roundtrip tests - not implemented for DC";
         } else {
           $run_roundtrip = $env:PYTHON + '\python.exe -m pytest --pyargs ' + $env:PARTNER_NAMESPACE + '.tests.docs.code.roundtrip -m "full_roundtrip"';

--- a/appveyor/dev/law-xml/appveyor.yml
+++ b/appveyor/dev/law-xml/appveyor.yml
@@ -47,7 +47,6 @@ before_build:
   - ps: $env:PARTNER_NAMESPACE = $CONTENT_ARRAY[1];
 
   - ps: |
-      $ErrorActionPreference = 'Stop'
       If ($env:TAF_BRANCH) {
         git clone -q git@github.com:openlawlibrary/taf.git ..\wheels\taf
         if ($LASTEXITCODE -ne 0) { throw "git clone taf failed" }

--- a/appveyor/dev/law-xml/appveyor.yml
+++ b/appveyor/dev/law-xml/appveyor.yml
@@ -46,38 +46,43 @@ before_build:
   - ps: $CONTENT_ARRAY = $REQUIREMENTS_CONTENT -split "# ";
   - ps: $env:PARTNER_NAMESPACE = $CONTENT_ARRAY[1];
 
-  - ps: >-
+  - ps: |
+      $ErrorActionPreference = 'Stop'
       If ($env:TAF_BRANCH) {
         git clone -q git@github.com:openlawlibrary/taf.git ..\wheels\taf
+        if ($LASTEXITCODE -ne 0) { throw "git clone taf failed" }
         git -C ..\wheels\taf checkout -q $env:TAF_BRANCH
+        if ($LASTEXITCODE -ne 0) { throw "git checkout taf branch failed" }
         $env:TAF_WHEEL = "-e ..\wheels\taf"
       } else {
         $env:TAF_WHEEL = "taf"
-      };
+      }
 
       If ($env:PLATFORM_BRANCH) {
         git clone -q git@github.com:openlawlibrary/platform.git ..\wheels\platform
+        if ($LASTEXITCODE -ne 0) { throw "git clone platform failed" }
         git -C ..\wheels\platform checkout -q $env:PLATFORM_BRANCH
+        if ($LASTEXITCODE -ne 0) { throw "git checkout platform branch failed" }
         $env:CORE_WHEEL = "-e ..\wheels\platform\core"
         If($env:PARTNER_NAMESPACE -eq 'oll.partners.us.dc') {
           $env:PARTNERS_WHEEL = "-e ..\wheels\platform\partners-us-dc"
-        }
-        else {
+        } else {
           $env:PARTNERS_WHEEL = "-e ..\wheels\platform\partners"
-        };
+        }
       } else {
         $env:CORE_WHEEL = "--pre oll-core"
         If($CONTENT_ARRAY[0] -match "~=") {
           $VERSION = $CONTENT_ARRAY[0] -split "~="
           $env:CORE_WHEEL += "~=" + $VERSION[1]
-        };
+        }
         $env:PARTNERS_WHEEL = "--pre " + $CONTENT_ARRAY[0]
-      };
+      }
 
   - "%PYTHON%\\python.exe -m pip -q install wheel"
   - "%PYTHON%\\python.exe -m pip -q install %TAF_WHEEL%"
   - "%PYTHON%\\python.exe -m pip -q install %CORE_WHEEL%"
   - "%PYTHON%\\python.exe -m pip -q install %PARTNERS_WHEEL%"
+  - "%PYTHON%\\python.exe -m pip check"
   - "%PYTHON%\\python.exe -m pip list"
 
   - "%PYTHON%\\python.exe  -m oll.tools.cli ci clone-repos-from-xml .. ../%APPVEYOR_PROJECT_SLUG% "
@@ -85,6 +90,7 @@ before_build:
   # install versioned resources (if and only if the build is a tag or cron build)
   - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
   - "%PYTHON%\\python.exe -m pip -q install pytest"
+  - "%PYTHON%\\python.exe -m pip check"
   # print out the git commits for xml repo
   - git -C ..\%UPSTREAM% rev-parse HEAD
 

--- a/appveyor/dev/law-xml/appveyor.yml
+++ b/appveyor/dev/law-xml/appveyor.yml
@@ -106,7 +106,7 @@ build_script:
 test_script:
   # run roundtrip tests
   - ps: >-
-      if ($env:APPVEYOR_REPO_BRANCH -eq 'master' -Or $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH -eq 'master'){
+      if ($env:APPVEYOR_REPO_BRANCH -in @('master', 'main') -Or $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH -in @('master', 'main')){
         cd $env:APPVEYOR_BUILD_FOLDER;
         $run_roundtrip = $env:PYTHON + '\python.exe -m pytest --pyargs ' + $env:PARTNER_NAMESPACE + '.tests.docs.code.roundtrip -m "full_roundtrip"';
         iex $run_roundtrip;
@@ -116,7 +116,7 @@ test_script:
           $host.SetShouldExit($LastExitCode)
         }
       } else {
-        echo "Skipping rountrip tests - not master branch build";
+        echo "Skipping rountrip tests - not master or main branch build";
       }
 notifications:
   - provider: Slack

--- a/appveyor/dev/law/appveyor.yml
+++ b/appveyor/dev/law/appveyor.yml
@@ -54,7 +54,6 @@ before_build:
   - ps: $REQUIREMENTS_CONTENT = Get-Content .\requirements.txt -Raw;
   - ps: $CONTENT_ARRAY = $REQUIREMENTS_CONTENT -split "# ";
   - ps: |
-      $ErrorActionPreference = 'Stop'
       If ($env:TAF_BRANCH) {
         git clone -q git@github.com:openlawlibrary/taf.git ..\wheels\taf
         if ($LASTEXITCODE -ne 0) { throw "git clone taf failed" }

--- a/appveyor/dev/law/appveyor.yml
+++ b/appveyor/dev/law/appveyor.yml
@@ -53,46 +53,52 @@ install:
 before_build:
   - ps: $REQUIREMENTS_CONTENT = Get-Content .\requirements.txt -Raw;
   - ps: $CONTENT_ARRAY = $REQUIREMENTS_CONTENT -split "# ";
-  - ps: >-
+  - ps: |
+      $ErrorActionPreference = 'Stop'
       If ($env:TAF_BRANCH) {
         git clone -q git@github.com:openlawlibrary/taf.git ..\wheels\taf
+        if ($LASTEXITCODE -ne 0) { throw "git clone taf failed" }
         git -C ..\wheels\taf checkout -q $env:TAF_BRANCH
+        if ($LASTEXITCODE -ne 0) { throw "git checkout taf branch failed" }
         $env:TAF_WHEEL = "-e ..\wheels\taf"
       } else {
         $env:TAF_WHEEL = "taf"
-      };
+      }
 
       If ($env:PLATFORM_BRANCH) {
         git clone -q git@github.com:openlawlibrary/platform.git ..\wheels\platform
+        if ($LASTEXITCODE -ne 0) { throw "git clone platform failed" }
         git -C ..\wheels\platform checkout -q $env:PLATFORM_BRANCH
+        if ($LASTEXITCODE -ne 0) { throw "git checkout platform branch failed" }
         $env:CORE_WHEEL = "-e ..\wheels\platform\core"
 
         If($env:PARTNER -eq 'OLL_PARTNERS_US_DC') {
           $env:PARTNERS_WHEEL = "-e ..\wheels\platform\partners-us-dc"
         } else {
           $env:PARTNERS_WHEEL = "-e ..\wheels\platform\partners"
-        };
+        }
       } else {
         $env:CORE_WHEEL = "--pre oll-core"
         If($CONTENT_ARRAY[0] -match "~=") {
           $VERSION = $CONTENT_ARRAY[0] -split "~="
           $env:CORE_WHEEL += "~=" + $VERSION[1]
-        };
+        }
         $env:PARTNERS_WHEEL = "--pre " + $CONTENT_ARRAY[0]
-      };
+      }
 
   - "%PYTHON%\\python.exe -m pip -q install wheel"
   - "%PYTHON%\\python.exe -m pip -q install %TAF_WHEEL%"
   - "%PYTHON%\\python.exe -m pip -q install %CORE_WHEEL%"
   - "%PYTHON%\\python.exe -m pip -q install %PARTNERS_WHEEL%"
+  - "%PYTHON%\\python.exe -m pip check"
   - "%PYTHON%\\python.exe -m pip list"
 
   - "%PYTHON%\\python.exe  -m oll.tools.cli ci clone-repos-from-auth .. ../%APPVEYOR_PROJECT_SLUG% "
 
   - git -C ..\%APPVEYOR_PROJECT_SLUG% remote set-url origin git@github.com:%APPVEYOR_REPO_NAME%.git
 
-  - "%PYTHON%\\python.exe -m pip -q install wheel"
   - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip check"
 
 build_script:
   - ps: $env:FLAG = if ($env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null) { "--deploy" }

--- a/appveyor/prod/law-xml/appveyor.yml
+++ b/appveyor/prod/law-xml/appveyor.yml
@@ -52,6 +52,7 @@ before_build:
 
   - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
   - "%PYTHON%\\python.exe -m pip -q install pytest"
+  - "%PYTHON%\\python.exe -m pip check"
   - "%PYTHON%\\python.exe -m pip list"
 
   - "%PYTHON%\\python.exe  -m oll.tools.cli ci clone-repos-from-xml .. ../%APPVEYOR_PROJECT_SLUG% "

--- a/appveyor/prod/law-xml/appveyor.yml
+++ b/appveyor/prod/law-xml/appveyor.yml
@@ -70,12 +70,16 @@ test_script:
   # uncomment when tests are implemented
   - ps: >-
       cd $env:APPVEYOR_BUILD_FOLDER;
-      $run_roundtrip = $env:PYTHON + '\python.exe -m pytest --pyargs ' + $env:PARTNER_NAMESPACE + '.tests.docs.code.roundtrip -m "full_roundtrip"';
-      iex $run_roundtrip;
-      if ($LastExitCode -eq 4 -or $LastExitCode -eq 5) {
-        Write-Warning "Skipping roundtrip tests - roundtrip tests not found";
-      } elseif ($LastExitCode -ne 0) {
-        $host.SetShouldExit($LastExitCode);
+      if ($env:PARTNER_NAMESPACE.Trim() -eq 'oll.partners.us.dc') {
+        Write-Warning "Skipping roundtrip tests - not implemented for DC";
+      } else {
+        $run_roundtrip = $env:PYTHON + '\python.exe -m pytest --pyargs ' + $env:PARTNER_NAMESPACE + '.tests.docs.code.roundtrip -m "full_roundtrip"';
+        iex $run_roundtrip;
+        if ($LastExitCode -eq 4 -or $LastExitCode -eq 5) {
+          Write-Warning "Skipping roundtrip tests - roundtrip tests not found";
+        } elseif ($LastExitCode -ne 0) {
+          $host.SetShouldExit($LastExitCode);
+        }
       }
 
 notifications:

--- a/appveyor/prod/law/appveyor.yml
+++ b/appveyor/prod/law/appveyor.yml
@@ -55,6 +55,7 @@ before_build:
 
   - "%PYTHON%\\python.exe -m pip -q install -r requirements.txt"
   - "%PYTHON%\\python.exe -m pip -q install pytest"
+  - "%PYTHON%\\python.exe -m pip check"
   - "%PYTHON%\\python.exe -m pip list"
 
   - "%PYTHON%\\python.exe  -m oll.tools.cli ci clone-repos-from-auth .. ../%APPVEYOR_PROJECT_SLUG% "


### PR DESCRIPTION
Adds pip check after package installation steps in dev and prod AppVeyor configs so that builds fail fast if there are broken or conflicting dependencies, rather than silently proceeding with a broken environment.

Also fixes the dev law config to stop on git errors in PowerShell blocks ($ErrorActionPreference = 'Stop' + $LASTEXITCODE checks), and removes a duplicate pip install wheel call.

Check failed - build failed:
https://ci.appveyor.com/project/oll-team/test-dccouncil-law/builds/54102523

Check passed (the build failed with a different, unrelated error): 
https://ci.appveyor.com/project/oll-team/test-sanipueblo-law-xml

Also skip non-existent roundtrip tests from DC:

[ttps://ci.appveyor.com/project/oll-team/dccouncil-law-xml/builds/54103279](https://ci.appveyor.com/project/oll-team/dccouncil-law-xml/builds/54103279) - red output  
vs https://ci.appveyor.com/project/oll-team/dccouncil-law-xml-1qje6